### PR TITLE
Fix output directory creation

### DIFF
--- a/tools/ioc_scraper/io_handler.py
+++ b/tools/ioc_scraper/io_handler.py
@@ -9,10 +9,12 @@ def read_text_file(filepath):
         return f.read()
 
 def write_json(output_path, data):
+    os.makedirs(os.path.dirname(output_path), exist_ok=True)
     with open(output_path, 'w') as f:
         json.dump(data, f, indent=4)
 
 def write_csv(output_path, data):
+    os.makedirs(os.path.dirname(output_path), exist_ok=True)
     with open(output_path, 'w', newline='') as f:
         writer = csv.writer(f)
         writer.writerow(["IOC Type", "Value"])


### PR DESCRIPTION
## Summary
- ensure IoC scraper creates the output folder

## Testing
- `python3 tools/ioc_scraper/ioc_scraper.py tools/ioc_scraper/ioc_scraper.py`

------
https://chatgpt.com/codex/tasks/task_e_686def11fa008333a88b9b97da0f91a1