### PR TITLE
Fix typo in ioc_scraper README

### DIFF
--- a/tools/ioc_scraper/README.md
+++ b/tools/ioc_scraper/README.md
@@ -18,5 +18,5 @@ python ioc_scraper.py test_inputs/sample.txt
   - MD5 hashes
 - Outputs results to:
     - Terminal (for quick review)
-    - JSON and CSV files (for futher use)
+    - JSON and CSV files (for further use)
 


### PR DESCRIPTION
## Summary
- correct a typo in the IOC scraper documentation

## Testing
- `git status --short`