### PR TITLE
Relocate tests under IoC scraper

### DIFF
--- a/tools/ioc_scraper/tests/test_regex_patterns.py
+++ b/tools/ioc_scraper/tests/test_regex_patterns.py
@@ -3,7 +3,7 @@ import sys
 import pytest
 
 # Allow tests to import the tools package from repository root
-sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[3]))
 
 from tools.ioc_scraper.regex_patterns import extract_iocs
 


### PR DESCRIPTION
## Summary
- move `tests` to `tools/ioc_scraper/tests`
- update import path to add repository root

## Testing
- `pytest -q`
